### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/scst/scst-rabbitmq-performance/.mvn/wrapper/.gitignore
+++ b/scst/scst-rabbitmq-performance/.mvn/wrapper/.gitignore
@@ -17,5 +17,5 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/scst/scst-rabbitmq-performance/README.md
+++ b/scst/scst-rabbitmq-performance/README.md
@@ -4,7 +4,7 @@
 
 This project contains scripts to test performances of a
 [Spring Cloud Stream](https://cloud.spring.io/spring-cloud-stream/) application
-using the [RabbitMQ](http://www.rabbitmq.com/) binder.
+using the [RabbitMQ](https://www.rabbitmq.com/) binder.
 The application is a simple Spring Cloud Stream sink.
 
 There are 3 roles in this benchmark:


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.java.com/en/download/help/error_hotspot.xml with 2 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).